### PR TITLE
Add OpenAI analysis module and simple auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration
+VITE_OPENAI_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/1adf9438-a94f-427a-a055-b2f31351c50c) and click on Share -> Publish.
 
+## Environment variables
+
+Create a `.env` file based on `.env.example` and provide your OpenAI API key to enable Telegram channel analysis.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
+    "openai": "^4.38.2",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/DashboardNavbar.tsx
+++ b/src/components/DashboardNavbar.tsx
@@ -1,12 +1,14 @@
 
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
+import { logout } from '@/lib/auth';
 import { LogOut, User, Settings } from 'lucide-react';
 
 const DashboardNavbar = () => {
   const navigate = useNavigate();
 
   const handleLogout = () => {
+    logout();
     navigate('/');
   };
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,62 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  passwordHash: string;
+}
+
+const USERS_KEY = 'tiap_users';
+const CURRENT_USER_KEY = 'tiap_current_user';
+
+function getUsers(): User[] {
+  const raw = localStorage.getItem(USERS_KEY);
+  return raw ? (JSON.parse(raw) as User[]) : [];
+}
+
+function saveUsers(users: User[]) {
+  localStorage.setItem(USERS_KEY, JSON.stringify(users));
+}
+
+async function hash(text: string): Promise<string> {
+  const data = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function register(name: string, email: string, password: string) {
+  const users = getUsers();
+  if (users.find((u) => u.email === email)) {
+    throw new Error('User already exists');
+  }
+  const passwordHash = await hash(password);
+  const user: User = {
+    id: crypto.randomUUID(),
+    name,
+    email,
+    passwordHash,
+  };
+  users.push(user);
+  saveUsers(users);
+  localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(user));
+}
+
+export async function login(email: string, password: string) {
+  const users = getUsers();
+  const passwordHash = await hash(password);
+  const user = users.find((u) => u.email === email && u.passwordHash === passwordHash);
+  if (!user) {
+    throw new Error('Invalid credentials');
+  }
+  localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(user));
+}
+
+export function logout() {
+  localStorage.removeItem(CURRENT_USER_KEY);
+}
+
+export function getCurrentUser(): User | null {
+  const raw = localStorage.getItem(CURRENT_USER_KEY);
+  return raw ? (JSON.parse(raw) as User) : null;
+}

--- a/src/lib/telegramAnalysis.ts
+++ b/src/lib/telegramAnalysis.ts
@@ -1,0 +1,55 @@
+import OpenAI from 'openai';
+
+export interface AnalysisParams {
+  channels: string[];
+  task: string;
+  type: string;
+}
+
+export interface AnalysisResult {
+  id: string;
+  params: AnalysisParams;
+  result: string;
+  date: string;
+}
+
+const HISTORY_KEY = 'tiap_analysis_history';
+
+function getApi() {
+  const apiKey = import.meta.env.VITE_OPENAI_KEY;
+  if (!apiKey) throw new Error('OPENAI key is missing');
+  return new OpenAI({ apiKey });
+}
+
+function getHistory(): AnalysisResult[] {
+  const raw = localStorage.getItem(HISTORY_KEY);
+  return raw ? (JSON.parse(raw) as AnalysisResult[]) : [];
+}
+
+function saveHistory(history: AnalysisResult[]) {
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+}
+
+export async function startAnalysis(params: AnalysisParams): Promise<AnalysisResult> {
+  const api = getApi();
+  const prompt = `Анализ Telegram каналов ${params.channels.join(', ')}. Задача: ${params.task}`;
+  const resp = await api.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const content = resp.choices[0]?.message?.content || '';
+  const res: AnalysisResult = {
+    id: crypto.randomUUID(),
+    params,
+    result: content,
+    date: new Date().toISOString(),
+  };
+  const history = getHistory();
+  history.unshift(res);
+  saveHistory(history);
+  return res;
+}
+
+export function listAnalyses(): AnalysisResult[] {
+  return getHistory();
+}

--- a/src/pages/AnalysisSetup.tsx
+++ b/src/pages/AnalysisSetup.tsx
@@ -9,6 +9,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, Search, Target, TrendingUp, User } from 'lucide-react';
 import DashboardNavbar from '@/components/DashboardNavbar';
+import { startAnalysis } from '@/lib/telegramAnalysis';
 
 const AnalysisSetup = () => {
   const navigate = useNavigate();
@@ -57,15 +58,17 @@ const AnalysisSetup = () => {
     }
   };
 
-  const handleStart = () => {
-    // Здесь будет логика запуска анализа
-    console.log('Запуск анализа с параметрами:', {
-      channelMethod,
-      channels,
-      analysisType,
-      customTask
-    });
-    navigate('/dashboard');
+  const handleStart = async () => {
+    try {
+      await startAnalysis({
+        channels: channels.split('\n').map((c) => c.trim()).filter(Boolean),
+        task: analysisType === 'custom' ? customTask : analysisType,
+        type: analysisType,
+      });
+      navigate('/dashboard');
+    } catch (err) {
+      alert((err as Error).message);
+    }
   };
 
   return (

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from 'react';
+import { register, login } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -14,10 +15,18 @@ const Auth = () => {
   const [name, setName] = useState('');
   const navigate = useNavigate();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Здесь будет логика аутентификации
-    navigate('/dashboard');
+    try {
+      if (isLogin) {
+        await login(email, password);
+      } else {
+        await register(name, email, password);
+      }
+      navigate('/dashboard');
+    } catch (err) {
+      alert((err as Error).message);
+    }
   };
 
   return (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,47 +1,22 @@
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { useNavigate } from 'react-router-dom';
 import { DollarSign, TrendingUp, Users, BarChart, Plus, Eye } from 'lucide-react';
 import DashboardNavbar from '@/components/DashboardNavbar';
+import { listAnalyses, AnalysisResult } from '@/lib/telegramAnalysis';
 
 const Dashboard = () => {
   const navigate = useNavigate();
   const [budget] = useState(1500);
   const [used] = useState(450);
+  const [analyses, setAnalyses] = useState<AnalysisResult[]>([]);
 
-  const analyses = [
-    {
-      id: 1,
-      name: "Анализ IT каналов",
-      type: "Поиск лидов",
-      status: "Завершен",
-      date: "15.12.2024",
-      channels: 25,
-      leads: 142
-    },
-    {
-      id: 2,
-      name: "Маркетинг криптовалют",
-      type: "Маркетинговый анализ",
-      status: "В процессе",
-      date: "18.12.2024",
-      channels: 18,
-      progress: 65
-    },
-    {
-      id: 3,
-      name: "Каналы для рекламы e-commerce",
-      type: "Выбор каналов для рекламы",
-      status: "Завершен",
-      date: "12.12.2024",
-      channels: 42,
-      recommendations: 8
-    }
-  ];
+  useEffect(() => {
+    setAnalyses(listAnalyses());
+  }, []);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
@@ -132,28 +107,23 @@ const Dashboard = () => {
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
+                  {analyses.length === 0 && (
+                    <p className="text-gray-400">Нет сохраненных анализов</p>
+                  )}
                   {analyses.map((analysis) => (
                     <div key={analysis.id} className="flex items-center justify-between p-4 bg-gray-700/50 rounded-lg">
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-2">
-                          <h3 className="font-medium text-white">{analysis.name}</h3>
-                          <Badge 
-                            variant={analysis.status === 'Завершен' ? 'default' : 'secondary'}
-                            className={analysis.status === 'Завершен' ? 'bg-green-600' : 'bg-orange-600'}
-                          >
-                            {analysis.status}
-                          </Badge>
+                          <h3 className="font-medium text-white">{analysis.params.task}</h3>
                         </div>
-                        <p className="text-sm text-gray-400 mb-2">{analysis.type}</p>
+                        <p className="text-sm text-gray-400 mb-2">{analysis.params.type}</p>
                         <div className="flex items-center gap-4 text-xs text-gray-500">
-                          <span>Каналов: {analysis.channels}</span>
-                          <span>Дата: {analysis.date}</span>
-                          {analysis.leads && <span>Лиды: {analysis.leads}</span>}
-                          {analysis.recommendations && <span>Рекомендации: {analysis.recommendations}</span>}
+                          <span>Каналов: {analysis.params.channels.length}</span>
+                          <span>Дата: {new Date(analysis.date).toLocaleDateString()}</span>
                         </div>
-                        {analysis.progress && (
-                          <Progress value={analysis.progress} className="mt-2 w-32" />
-                        )}
+                        <p className="text-gray-400 mt-2 text-sm">
+                          {analysis.result.slice(0, 80)}...
+                        </p>
                       </div>
                       <Button size="sm" variant="outline" className="text-white border-gray-600">
                         <Eye className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- implement a lightweight local auth module and wire it into registration and login
- track analyses using a new Telegram analysis module that calls OpenAI
- hook dashboard into stored analyses instead of demo data
- allow starting real analysis from setup page
- document environment variables
- provide `.env.example` and add OpenAI dependency
- fix OpenAI integration and dashboard mapping

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*